### PR TITLE
New version 1.4.0.1

### DIFF
--- a/Parser/JsonObjects/Yahoo/YahooHistoryData.cs
+++ b/Parser/JsonObjects/Yahoo/YahooHistoryData.cs
@@ -27,7 +27,14 @@ namespace Parser.JsonObjects.Yahoo
     // Root myDeserializedClass = JsonConvert.DeserializeObject<Root>(myJsonResponse);
     public class Adjclose
     {
-        public List<double> AdjcloseData { get; set; }
+        public List<double?> AdjClose { get; set; }
+    }
+
+    public partial class Result
+    {
+        public Meta Meta { get; set; }
+        public List<int> Timestamp { get; set; }
+        public Indicators Indicators { get; set; }
     }
 
     public class Chart
@@ -55,7 +62,7 @@ namespace Parser.JsonObjects.Yahoo
         public string Symbol { get; set; }
         public string ExchangeName { get; set; }
         public string InstrumentType { get; set; }
-        public int FirstTradeDate { get; set; }
+        public object FirstTradeDate { get; set; }
         public int RegularMarketTime { get; set; }
         public int Gmtoffset { get; set; }
         public string Timezone { get; set; }
@@ -72,8 +79,8 @@ namespace Parser.JsonObjects.Yahoo
     public class Post
     {
         public string Timezone { get; set; }
-        public int Start { get; set; }
         public int End { get; set; }
+        public int Start { get; set; }
         public int Gmtoffset { get; set; }
     }
 
@@ -87,34 +94,23 @@ namespace Parser.JsonObjects.Yahoo
 
     public class Quote
     {
-        public List<double> Low { get; set; }
-        public List<int> Volume { get; set; }
-        public List<double> High { get; set; }
-        public List<double> Close { get; set; }
-        public List<double> Open { get; set; }
+        public List<double?> Low { get; set; }
+        public List<double?> Close { get; set; }
+        public List<double?> Open { get; set; }
+        public List<double?> High { get; set; }
+        public List<int?> Volume { get; set; }
     }
 
     public class Regular
     {
         public string Timezone { get; set; }
-        public int Start { get; set; }
         public int End { get; set; }
+        public int Start { get; set; }
         public int Gmtoffset { get; set; }
-    }
-
-    public partial class Result
-    {
-        public Meta Meta { get; set; }
-        public List<int> Timestamp { get; set; }
-        public Indicators Indicators { get; set; }
     }
 
     public class HistoryData
     {
         public Chart Chart { get; set; }
     }
-
-
-
-
 }

--- a/Parser/Properties/AssemblyInfo.cs
+++ b/Parser/Properties/AssemblyInfo.cs
@@ -53,5 +53,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.4.0.1")]
+[assembly: AssemblyFileVersion("1.4.0.1")]


### PR DESCRIPTION
New features / improvements:
- The YahooHistoryData object has been modified to handle "null" objects for "firstTradeDate
- If the WebClient download failed the error will be set to the ParserInfoState property "Exception"

Removed features:
- None

Fixed bugs:
- At the Yahoo history data it could happen that "null" values will be given by the REST- API.
  This "null" values were also be set to the daily values list and has "0" values as result in the history graph.
  This "null" values will no more be added and the history graph is valid again.

Know bugs:
- None